### PR TITLE
KAA-504: Record field name uniqueness fix

### DIFF
--- a/converter/src/main/java/org/kaaproject/avro/ui/converter/FormAvroConverter.java
+++ b/converter/src/main/java/org/kaaproject/avro/ui/converter/FormAvroConverter.java
@@ -69,7 +69,7 @@ public class FormAvroConverter implements ConverterConstants {
         if (formField instanceof RecordField) {
             return (RecordField)formField;
         } else {
-            throw new IllegalArgumentException("Schema " + schema.getFullName() + " is not record schema!");
+            throw new IllegalArgumentException("Schema " + schema.getFullName() + " is not a record schema!");
         }
     }
     

--- a/converter/src/main/java/org/kaaproject/avro/ui/converter/FormAvroConverter.java
+++ b/converter/src/main/java/org/kaaproject/avro/ui/converter/FormAvroConverter.java
@@ -239,7 +239,7 @@ public class FormAvroConverter implements ConverterConstants {
             if (!schemaFieldNames.contains(schemaFieldName)) {
                 schemaFieldNames.add(schemaFieldName);
             } else {
-                throw new IllegalArgumentException("Dublicate field name: " + schemaFieldName);
+                throw new IllegalArgumentException("Duplicate field name: " + schemaFieldName);
             }
 
             FieldType fieldType = toFieldType(field.schema());

--- a/converter/src/main/java/org/kaaproject/avro/ui/converter/FormAvroConverter.java
+++ b/converter/src/main/java/org/kaaproject/avro/ui/converter/FormAvroConverter.java
@@ -239,7 +239,7 @@ public class FormAvroConverter implements ConverterConstants {
             if (!schemaFieldNames.contains(schemaFieldName)) {
                 schemaFieldNames.add(schemaFieldName);
             } else {
-                throw new RuntimeException("Field names are not unique!");
+                throw new IllegalArgumentException("Dublicate field name: " + schemaFieldName);
             }
 
             FieldType fieldType = toFieldType(field.schema());

--- a/converter/src/main/java/org/kaaproject/avro/ui/converter/FormAvroConverter.java
+++ b/converter/src/main/java/org/kaaproject/avro/ui/converter/FormAvroConverter.java
@@ -232,7 +232,15 @@ public class FormAvroConverter implements ConverterConstants {
      */
     private static void parseFields(RecordField rootRecord, RecordField formData, Schema schema) throws IOException {
         List<Field> schemaFields = schema.getFields();
+        java.util.Set<String> schemaFieldNames = new java.util.HashSet<>();
+
         for (Field field : schemaFields) {
+            String schemaFieldName = field.name().toLowerCase();
+            if (!schemaFieldNames.contains(schemaFieldName)) {
+                schemaFieldNames.add(schemaFieldName);
+            } else {
+                throw new RuntimeException("Field names are not unique!");
+            }
 
             FieldType fieldType = toFieldType(field.schema());
             FormField formField = createFieldFromSchema(rootRecord, field.schema());

--- a/converter/src/main/java/org/kaaproject/avro/ui/converter/SchemaFormAvroConverter.java
+++ b/converter/src/main/java/org/kaaproject/avro/ui/converter/SchemaFormAvroConverter.java
@@ -462,7 +462,7 @@ public class SchemaFormAvroConverter implements ConverterConstants, SchemaFormCo
                             if (!fieldNames.contains(fieldName)) {
                                 fieldNames.add(fieldName);
                             } else {
-                                throw new RuntimeException("Field names are not unique!");
+                                throw new IllegalArgumentException("Dublicate field name: " + fieldName);
                             }
 
                             fieldsArrayData.add(createFormFieldFromSchemaField(fieldSchema, field, namedFqns));

--- a/converter/src/main/java/org/kaaproject/avro/ui/converter/SchemaFormAvroConverter.java
+++ b/converter/src/main/java/org/kaaproject/avro/ui/converter/SchemaFormAvroConverter.java
@@ -462,7 +462,7 @@ public class SchemaFormAvroConverter implements ConverterConstants, SchemaFormCo
                             if (!fieldNames.contains(fieldName)) {
                                 fieldNames.add(fieldName);
                             } else {
-                                throw new IllegalArgumentException("Dublicate field name: " + fieldName);
+                                throw new IllegalArgumentException("Duplicate field name: " + fieldName);
                             }
 
                             fieldsArrayData.add(createFormFieldFromSchemaField(fieldSchema, field, namedFqns));

--- a/converter/src/main/java/org/kaaproject/avro/ui/converter/SchemaFormAvroConverter.java
+++ b/converter/src/main/java/org/kaaproject/avro/ui/converter/SchemaFormAvroConverter.java
@@ -455,8 +455,16 @@ public class SchemaFormAvroConverter implements ConverterConstants, SchemaFormCo
                         GenericData.Array<Object> fieldsArrayData = new GenericData.Array<>(fields.size(), fieldsField.schema());
                         
                         Schema fieldSchema = fieldsField.schema().getElementType();
+                        java.util.Set<String> fieldNames = new java.util.HashSet<>();
                         
                         for (Field field : fields) {
+                            String fieldName = field.name().toLowerCase();
+                            if (!fieldNames.contains(fieldName)) {
+                                fieldNames.add(fieldName);
+                            } else {
+                                throw new RuntimeException("Field names are not unique!");
+                            }
+
                             fieldsArrayData.add(createFormFieldFromSchemaField(fieldSchema, field, namedFqns));
                         }
                         record.put(FIELDS, fieldsArrayData);


### PR DESCRIPTION
Added a check to ensure record field names are unique (case-insensitive). If a schema containing non-unique field names is parsed, an exception occures. No suitable class was found to encapsulate that exception throw (org.kaaproject.avro.ui.shared.NamesValidator contains logic to validate a single name, not a bunch of them).