### PR TITLE
KAA-644: Add a null check for a required boolean field

### DIFF
--- a/converter/src/main/java/org/kaaproject/avro/ui/converter/FormAvroConverter.java
+++ b/converter/src/main/java/org/kaaproject/avro/ui/converter/FormAvroConverter.java
@@ -905,6 +905,10 @@ public class FormAvroConverter implements ConverterConstants {
         case DOUBLE:
             return ((DoubleField)formField).getValue();
         case BOOLEAN:
+            // Explicitly set if the field is left untouched by the user
+            if (((BooleanField) formField).getValue() == null && !formField.isOptional()) {
+                ((BooleanField) formField).setValue(Boolean.FALSE);
+            }
             return ((BooleanField)formField).getValue();
         case BYTES:
             BytesField bytesField = (BytesField)formField;


### PR DESCRIPTION
If a required boolean field is left untouched on a form, its value is not FALSE as expected, but NULL. This commit fixes the issue.